### PR TITLE
Fix logging config: level labels, syslog/file exclusivity, v1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ cd pfsense-dnscrypt-proxy
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEPLOY_HOST` | `pf` | SSH hostname for pfSense |
-| `PORTVERSION` | `1.2.2` | Package version to build |
+| `PORTVERSION` | `1.2.3` | Package version to build |
 
 ## Related
 

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ set -e
 
 # --- Configuration ---
 PORTNAME="pfSense-pkg-dnscrypt-proxy"
-PORTVERSION="${PORTVERSION:-1.2.2}"
+PORTVERSION="${PORTVERSION:-1.2.3}"
 PREFIX="/usr/local"
 DATADIR="${PREFIX}/share/${PORTNAME}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -38,7 +38,7 @@ usage() {
     echo ""
     echo "Environment variables:"
     echo "  DEPLOY_HOST    pfSense SSH host (default: pf)"
-    echo "  PORTVERSION    Package version (default: 1.2.2)"
+    echo "  PORTVERSION    Package version (default: 1.2.3)"
 }
 
 clean() {

--- a/files/usr/local/pkg/dnscrypt-proxy-advanced.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy-advanced.xml
@@ -29,6 +29,7 @@
 	<title>Services: DNSCrypt Proxy</title>
 	<shortcut_section>dnscrypt-proxy</shortcut_section>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy-advanced.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>

--- a/files/usr/local/pkg/dnscrypt-proxy-cache.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy-cache.xml
@@ -29,6 +29,7 @@
 	<title>Services: DNSCrypt Proxy</title>
 	<shortcut_section>dnscrypt-proxy</shortcut_section>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy-cache.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>

--- a/files/usr/local/pkg/dnscrypt-proxy-lists.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy-lists.xml
@@ -29,6 +29,7 @@
 	<title>Services: DNSCrypt Proxy</title>
 	<shortcut_section>dnscrypt-proxy</shortcut_section>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy-lists.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>

--- a/files/usr/local/pkg/dnscrypt-proxy-logging.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy-logging.xml
@@ -29,6 +29,7 @@
 	<title>Services: DNSCrypt Proxy</title>
 	<shortcut_section>dnscrypt-proxy</shortcut_section>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy-logging.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>
@@ -74,30 +75,34 @@
 		<field>
 			<fielddescr>Log Level</fielddescr>
 			<fieldname>log_level</fieldname>
-			<description>Logging verbosity (0=off to 6=debug)</description>
+			<description>Logging verbosity (0=debug/verbose to 6=fatal only)</description>
 			<type>select</type>
 			<default_value>2</default_value>
 			<options>
-				<option><name>0 - Off</name><value>0</value></option>
-				<option><name>1 - Fatal</name><value>1</value></option>
-				<option><name>2 - Error (default)</name><value>2</value></option>
+				<option><name>0 - Debug (very verbose)</name><value>0</value></option>
+				<option><name>1 - Info</name><value>1</value></option>
+				<option><name>2 - Notice (default)</name><value>2</value></option>
 				<option><name>3 - Warning</name><value>3</value></option>
-				<option><name>4 - Notice</name><value>4</value></option>
-				<option><name>5 - Info</name><value>5</value></option>
-				<option><name>6 - Debug</name><value>6</value></option>
+				<option><name>4 - Error</name><value>4</value></option>
+				<option><name>5 - Critical</name><value>5</value></option>
+				<option><name>6 - Fatal (least verbose)</name><value>6</value></option>
 			</options>
 		</field>
 		<field>
-			<fielddescr>Use Syslog</fielddescr>
-			<fieldname>use_syslog</fieldname>
-			<description>Send log messages to syslog (viewable in Status &gt; System Logs)</description>
-			<type>checkbox</type>
-			<default_value>on</default_value>
+			<fielddescr>Log Destination</fielddescr>
+			<fieldname>log_destination</fieldname>
+			<description>Where to send log messages. Only one can be active at a time.</description>
+			<type>select</type>
+			<default_value>syslog</default_value>
+			<options>
+				<option><name>Syslog (Status &gt; System Logs)</name><value>syslog</value></option>
+				<option><name>Log File</name><value>file</value></option>
+			</options>
 		</field>
 		<field>
-			<fielddescr>Log File</fielddescr>
+			<fielddescr>Log File Path</fielddescr>
 			<fieldname>log_file</fieldname>
-			<description>Optional path to a log file (leave empty to use syslog only)</description>
+			<description>Path to log file. Only used when Log Destination is set to "Log File".</description>
 			<type>input</type>
 			<size>50</size>
 		</field>
@@ -120,6 +125,9 @@
 			<default_value>/var/log/dnscrypt-proxy/query.log</default_value>
 		</field>
 	</fields>
+	<custom_php_after_form_command>
+		dnscrypt_proxy_logging_after_form();
+	</custom_php_after_form_command>
 	<custom_php_resync_config_command>
 		dnscrypt_proxy_sync();
 	</custom_php_resync_config_command>

--- a/files/usr/local/pkg/dnscrypt-proxy-servers.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy-servers.xml
@@ -29,6 +29,7 @@
 	<title>Services: DNSCrypt Proxy</title>
 	<shortcut_section>dnscrypt-proxy</shortcut_section>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy-servers.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -165,7 +165,7 @@ function dnscrypt_proxy_get_defaults() {
 		'block_unqualified' => 'on',
 		'block_undelegated' => 'on',
 		'log_level' => '2',
-		'use_syslog' => 'on',
+		'log_destination' => 'syslog',
 		'log_file' => '',
 		'query_log' => '',
 		'query_log_file' => '/var/log/dnscrypt-proxy/query.log',
@@ -226,7 +226,7 @@ function dnscrypt_proxy_get_all_fields() {
 		'cache', 'cache_size', 'cache_min_ttl', 'cache_max_ttl',
 		'block_ipv6', 'block_unqualified', 'block_undelegated',
 		// Logging tab
-		'log_level', 'use_syslog', 'log_file', 'query_log', 'query_log_file',
+		'log_level', 'log_destination', 'log_file', 'query_log', 'query_log_file',
 		// Lists tab
 		'blocked_names', 'allowed_names', 'forwarding_rules', 'cloaking_rules',
 		// Advanced tab
@@ -252,7 +252,7 @@ function dnscrypt_proxy_get_tab_checkboxes() {
 		                   'require_dnssec', 'require_nolog', 'require_nofilter',
 		                   'anon_dns_enable', 'anon_dns_skip_incompatible', 'anon_dns_direct_cert_fallback'),
 		'cache' => array('cache', 'block_ipv6', 'block_unqualified', 'block_undelegated'),
-		'logging' => array('use_syslog', 'query_log'),
+		'logging' => array('query_log'),
 		'advanced' => array('force_tcp', 'http3', 'offline_mode', 'odoh_servers',
 		                    'dnscrypt_ephemeral_keys', 'tls_disable_session_tickets')
 	);
@@ -299,6 +299,29 @@ function dnscrypt_proxy_detect_current_tab() {
 	}
 
 	return null;
+}
+
+/**
+ * Inject JavaScript to toggle Log File Path visibility based on Log Destination
+ */
+function dnscrypt_proxy_logging_after_form() {
+?>
+<script type="text/javascript">
+events.push(function() {
+	function toggleLogFile() {
+		var dest = $('select[name="log_destination"]').val();
+		var input = $('input[name="log_file"]');
+		if (dest === 'file') {
+			input.prop('disabled', false);
+		} else {
+			input.prop('disabled', true);
+		}
+	}
+	$('select[name="log_destination"]').on('change', toggleLogFile);
+	toggleLogFile();
+});
+</script>
+<?php
 }
 
 /**
@@ -617,6 +640,12 @@ function dnscrypt_proxy_validate($post, &$input_errors) {
 	}
 	if (!empty($post['blocked_query_response']) && !in_array($post['blocked_query_response'], array('hinfo', 'refused', 'empty'))) {
 		$input_errors[] = "Invalid blocked query response type.";
+	}
+	if (!empty($post['log_destination']) && !in_array($post['log_destination'], array('syslog', 'file'))) {
+		$input_errors[] = "Invalid log destination.";
+	}
+	if (isset($post['log_destination']) && $post['log_destination'] === 'file' && empty($post['log_file'])) {
+		$input_errors[] = "Log File Path is required when Log Destination is set to 'Log File'.";
 	}
 	if (!empty($post['log_level']) && !in_array($post['log_level'], array('0', '1', '2', '3', '4', '5', '6'))) {
 		$input_errors[] = "Invalid log level. Must be 0-6.";
@@ -1027,7 +1056,7 @@ function dnscrypt_proxy_import_toml($toml_content) {
 		'odoh_servers', 'require_dnssec', 'require_nolog', 'require_nofilter',
 		'ignore_system_dns', 'force_tcp', 'http3', 'offline_mode',
 		'cache', 'block_ipv6', 'block_unqualified', 'block_undelegated',
-		'use_syslog', 'dnscrypt_ephemeral_keys', 'tls_disable_session_tickets'
+		'dnscrypt_ephemeral_keys', 'tls_disable_session_tickets'
 	);
 
 	// Numeric/string fields that map directly
@@ -1047,7 +1076,7 @@ function dnscrypt_proxy_import_toml($toml_content) {
 	// Track which keys we've handled
 	$handled_keys = array_merge($bool_fields, $direct_fields, $string_fields,
 		array('listen_addresses', 'server_names', 'disabled_server_names',
-		      'bootstrap_resolvers'));
+		      'bootstrap_resolvers', 'use_syslog'));
 
 	// Process boolean fields
 	foreach ($bool_fields as $field) {
@@ -1069,6 +1098,12 @@ function dnscrypt_proxy_import_toml($toml_content) {
 		if (isset($top_level[$field])) {
 			$config[$field] = $parse_value($top_level[$field]);
 		}
+	}
+
+	// use_syslog + log_file → log_destination
+	if (isset($top_level['use_syslog'])) {
+		$val = $parse_value($top_level['use_syslog']);
+		$config['log_destination'] = ($val === true) ? 'syslog' : 'file';
 	}
 
 	// listen_addresses → extract port from first entry
@@ -1545,8 +1580,9 @@ function dnscrypt_proxy_generate_toml() {
 	$block_unqualified = isset($pkg_config['block_unqualified']) && $pkg_config['block_unqualified'] == 'on' ? 'true' : 'false';
 	$block_undelegated = isset($pkg_config['block_undelegated']) && $pkg_config['block_undelegated'] == 'on' ? 'true' : 'false';
 
-	// Boolean settings - Logging
-	$use_syslog = isset($pkg_config['use_syslog']) && $pkg_config['use_syslog'] == 'on' ? 'true' : 'false';
+	// Logging destination - syslog and log_file are mutually exclusive in dnscrypt-proxy
+	$log_destination = isset($pkg_config['log_destination']) ? $pkg_config['log_destination'] : 'syslog';
+	$use_syslog = ($log_destination === 'syslog') ? 'true' : 'false';
 
 	// Boolean settings - Security/privacy
 	$dnscrypt_ephemeral_keys = isset($pkg_config['dnscrypt_ephemeral_keys']) && $pkg_config['dnscrypt_ephemeral_keys'] == 'on' ? 'true' : 'false';
@@ -1562,11 +1598,9 @@ function dnscrypt_proxy_generate_toml() {
 	if (!isset($pkg_config['cache'])) $cache_enabled = 'true';
 	if (!isset($pkg_config['block_unqualified'])) $block_unqualified = 'true';
 	if (!isset($pkg_config['block_undelegated'])) $block_undelegated = 'true';
-	if (!isset($pkg_config['use_syslog'])) $use_syslog = 'true';
-
-	// Log file
+	// Log file - only used when destination is 'file'
 	$log_file_line = '';
-	if (!empty($pkg_config['log_file'])) {
+	if ($log_destination === 'file' && !empty($pkg_config['log_file'])) {
 		$log_file_line = "log_file = '" . dnscrypt_proxy_toml_safe($pkg_config['log_file']) . "'\n";
 	}
 

--- a/files/usr/local/pkg/dnscrypt-proxy.xml
+++ b/files/usr/local/pkg/dnscrypt-proxy.xml
@@ -42,6 +42,7 @@
 		<starts_on_sync/>
 	</service>
 	<configpath>installedpackages->dnscryptproxy->config</configpath>
+	<addedit_string>[dnscrypt-proxy] Settings saved</addedit_string>
 	<aftersaveredirect>/pkg_edit.php?xml=dnscrypt-proxy.xml</aftersaveredirect>
 	<include_file>/usr/local/pkg/dnscrypt-proxy.inc</include_file>
 	<tabs>


### PR DESCRIPTION
## Summary
- Fix inverted log level labels — now matches dnscrypt-proxy's `dlog` severity constants (0=Debug/verbose → 6=Fatal/quiet). Previously selecting "Debug" in the UI set `log_level = 6`, which is the *least* verbose level.
- Replace separate `Use Syslog` checkbox and `Log File` input with a single `Log Destination` select (Syslog / Log File). dnscrypt-proxy treats these as mutually exclusive (`if/else if` in source); the old UI presented them as independent options.
- Log File Path input is disabled (greyed out) when Syslog is selected.
- Add `addedit_string` to all tab XML files to fix pfSense `write_config() called without description` warning on every save.
- Bump version to 1.2.3.

Closes #10

## Test plan
- [x] Verify log level labels display correctly (0=Debug through 6=Fatal)
- [x] Set log level to Debug (0), confirm dnscrypt-proxy TOML has `log_level = 0` and verbose output appears
- [x] Switch Log Destination between Syslog and Log File, confirm Log File Path input enables/disables accordingly
- [x] Set destination to Log File with a path, save, confirm TOML has `log_file` and `use_syslog = false`
- [x] Set destination to Syslog, save, confirm TOML has `use_syslog = true` and no `log_file` line
- [x] Try saving with Log File destination and empty path — should get validation error
- [x] Save settings on each tab, confirm no `write_config() called without description` warning in pfSense logs
- [x] Import a TOML config with `use_syslog = true`, verify it maps to Log Destination = Syslog
- [x] Import a TOML config with `use_syslog = false` and `log_file = '/var/log/dnscrypt-proxy/dnscrypt-proxy.log'`, verify it maps to Log Destination = Log File