### PR TITLE
Fix stale bundled-version constant; ship dnscrypt-proxy 2.1.16 as 1.2.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,18 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version: ${VERSION}"
+
+          # Guard against tagging the wrong commit: for tag-triggered releases
+          # the tag version must match PORTVERSION at that commit. (A mismatch
+          # is how v1.2.5 once shipped a stale binary.) Skip for manual dispatch.
+          if [ "${EVENT_NAME}" != "workflow_dispatch" ]; then
+            MK=$(grep '^PORTVERSION=' Makefile | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ "${VERSION}" != "${MK}" ]; then
+              echo "::error::Tag v${VERSION} does not match Makefile PORTVERSION ${MK} at this commit. Tag the commit that contains the version bump." >&2
+              exit 1
+            fi
+          fi
+
           if [ -f .upstream-version ]; then
             UPSTREAM=$(tr -d '[:space:]' < .upstream-version)
           else

--- a/.github/workflows/upstream-update.yml
+++ b/.github/workflows/upstream-update.yml
@@ -112,6 +112,16 @@ jobs:
           # Record new upstream version.
           echo "${VER}" > .upstream-version
 
+          # Keep the UI-facing bundled-version constant in sync with the
+          # binary. This is what "DNSCrypt Proxy Version" shows in the GUI
+          # (and is stored as binary_version at install time).
+          sed -i "s/define('DNSCRYPT_PROXY_VERSION', '[^']*')/define('DNSCRYPT_PROXY_VERSION', '${VER}')/" \
+            files/usr/local/pkg/dnscrypt-proxy.inc
+          if ! grep -q "define('DNSCRYPT_PROXY_VERSION', '${VER}')" files/usr/local/pkg/dnscrypt-proxy.inc; then
+            echo "Failed to update DNSCRYPT_PROXY_VERSION constant" >&2
+            exit 1
+          fi
+
           echo "NEWPKG=${NEWPKG}" >> "$GITHUB_ENV"
 
       - name: Open pull request

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-dnscrypt-proxy
-PORTVERSION=	1.2.5
+PORTVERSION=	1.2.6
 CATEGORIES=	dns
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/build/+MANIFEST
+++ b/build/+MANIFEST
@@ -1,5 +1,5 @@
 name: "pfSense-pkg-dnscrypt-proxy"
-version: "1.2.5"
+version: "1.2.6"
 origin: "dns/pfSense-pkg-dnscrypt-proxy"
 comment: "pfSense package for DNSCrypt Proxy encrypted DNS client"
 maintainer: "ports@FreeBSD.org"

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -30,7 +30,7 @@ define('DNSCRYPT_PROXY_RCFILE', '/usr/local/etc/rc.d/dnscrypt-proxy.sh');
 define('DNSCRYPT_PROXY_CONFIG', DNSCRYPT_PROXY_BASE . '/dnscrypt-proxy.toml');
 define('DNSCRYPT_PROXY_LOGDIR', '/var/log/dnscrypt-proxy');
 define('DNSCRYPT_PROXY_BUNDLED_DIR', '/usr/local/bin/dnscrypt-proxy-bin');
-define('DNSCRYPT_PROXY_VERSION', '2.1.15');
+define('DNSCRYPT_PROXY_VERSION', '2.1.16');
 
 /**
  * Get package configuration


### PR DESCRIPTION
Fixes the GUI showing "DNSCrypt Proxy Version 2.1.15" while the bundled binary is actually 2.1.16.

## Background
The released `v1.2.5` package shipped the **old 2.1.15 binary** because the `v1.2.5` tag was pushed onto a commit (`229a479`) before the binary-swap PR (#13) was merged. The release workflow builds from the tagged commit but labels the package from the tag name, so a `1.2.5`-labeled package carried `2.1.15` contents.

## Changes
- **`dnscrypt-proxy.inc`**: correct `DNSCRYPT_PROXY_VERSION` constant `2.1.15` -> `2.1.16` (this is what the GUI displays / stores as `binary_version`).
- **`Makefile` / `build/+MANIFEST`**: bump package `1.2.5` -> `1.2.6` so a fresh release ships the corrected files (binary is already 2.1.16 on main).
- **`upstream-update.yml`**: the auto-update workflow now rewrites the version constant whenever it swaps the binary, so the GUI version stays in sync going forward.
- **`release.yml`**: guard tag-triggered builds — fail if the tag version != `PORTVERSION` at the tagged commit. This would have caught the original `v1.2.5` mistake.

## After merge
Tag `v1.2.6` on the merge commit (not before!) to build a correct release, then reinstall on the box.