### PR TITLE
Add CI pipeline and harden release supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current. Dependabot bumps the pinned
+  # digest and updates the trailing version comment, so pinning does not mean
+  # going stale.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       # heredoc expansion) and tracked separately.
       - name: Run shellcheck
         run: |
-          shellcheck ./*.sh
+          shellcheck ./*.sh || true
           echo "--- gating on error severity ---"
           shellcheck --severity=error ./*.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+# Static checks on every pull request and on pushes to main. Nothing here
+# builds or releases; it only gates code quality and workflow security so a
+# regression cannot reach main unreviewed.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Default to no privileges; each job opts in to exactly what it needs.
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      # shellcheck is preinstalled on ubuntu-latest. Print every finding for
+      # visibility, but only fail the job on error-level issues. Pre-existing
+      # info/warning items in build.sh are intentional (client-side ssh
+      # heredoc expansion) and tracked separately.
+      - name: Run shellcheck
+        run: |
+          shellcheck ./*.sh
+          echo "--- gating on error severity ---"
+          shellcheck --severity=error ./*.sh
+
+  php-lint:
+    name: PHP lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      # php-cli is preinstalled on ubuntu-latest. Lint every PHP source the
+      # package ships (GUI pages and pfSense .inc includes).
+      - name: php -l all PHP sources
+        run: |
+          find files \( -name '*.php' -o -name '*.inc' \) -print0 \
+            | xargs -0 -r -n1 php -l
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      ACTIONLINT_VERSION: 1.7.12
+      ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      # Download a pinned actionlint release and verify its checksum before
+      # executing it, rather than piping an install script straight to a shell.
+      - name: Install actionlint (verified)
+        run: |
+          set -euo pipefail
+          TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          URL="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${TARBALL}"
+          curl -fsSL -o "${TARBALL}" "${URL}"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar -xzf "${TARBALL}" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+
+      - name: Run actionlint
+        run: actionlint -color
+
+  workflow-security:
+    name: zizmor (Actions SAST)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      # zizmor statically audits the workflows for the same class of issues
+      # this repo already guards by hand (template injection, unpinned actions,
+      # credential persistence, over-broad permissions).
+      - name: Install zizmor
+        run: pip install zizmor==1.25.2
+
+      - name: Audit workflows
+        run: zizmor --offline --min-severity=low .github/workflows/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,27 @@ on:
         required: true
         default: '1.1.2'
 
-permissions:
-  contents: write
+# Default to no privileges; the job grants exactly what it needs below.
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build Package on FreeBSD
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # create the release and upload assets
+      id-token: write       # mint the OIDC token for build provenance
+      attestations: write   # record the SLSA attestation
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
@@ -95,13 +105,36 @@ jobs:
           echo "=== Built packages ==="
           ls -la ./*.pkg ./*.txz 2>/dev/null || true
 
+      - name: Generate SHA256 checksums
+        run: |
+          set -euo pipefail
+          # Hash every downloadable package (versioned and the unversioned
+          # "latest" copy, whether .pkg or .txz) so users can verify what they
+          # pull from the release.
+          : > SHA256SUMS
+          for f in pfSense-pkg-dnscrypt-proxy*.pkg pfSense-pkg-dnscrypt-proxy*.txz; do
+            [ -e "$f" ] && sha256sum "$f" >> SHA256SUMS
+          done
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
+      # Cryptographic build provenance (SLSA): binds each package to this
+      # workflow, commit, and runner. Feeding the checksums file attests every
+      # listed artifact regardless of extension. Verifiable later with
+      # `gh attestation verify <file> --repo <owner>/<repo>`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-checksums: SHA256SUMS
+
       - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pfSense-pkg-dnscrypt-proxy
           path: |
             *.pkg
             *.txz
+            SHA256SUMS
           if-no-files-found: error
 
       - name: Create GitHub Release
@@ -111,6 +144,7 @@ jobs:
           files: |
             *.pkg
             *.txz
+            SHA256SUMS
           body: |
             Bundles **dnscrypt-proxy ${{ steps.version.outputs.upstream }}** (upstream).
 

--- a/.github/workflows/upstream-update.yml
+++ b/.github/workflows/upstream-update.yml
@@ -30,7 +30,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Determine versions
         id: versions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # pfSense DNSCrypt Proxy Package
 
+[![CI](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/nopoz/pfsense-dnscrypt-proxy?sort=semver)](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
+[![Build provenance](https://img.shields.io/badge/build%20provenance-attested-success)](SECURITY.md#verifying-a-download)
+[![License: ISC](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
+
 A pfSense package providing a full GUI for [DNSCrypt Proxy](https://github.com/DNSCrypt/dnscrypt-proxy), an encrypted DNS client supporting DNSCrypt v2, DNS-over-HTTPS (DoH), Oblivious DoH (ODoH), and Anonymized DNS protocols.
 
 > **Note:** This is a community-maintained package and is not affiliated with or supported by Netgate.
@@ -192,6 +197,22 @@ cd pfsense-dnscrypt-proxy
 - [pfSense FreeBSD-ports PR #1434](https://github.com/pfsense/FreeBSD-ports/pull/1434) - Submission to the official pfSense package repository
 - [pfSense Redmine #9315](https://redmine.pfsense.org/issues/9315) - Original feature request
 - [Netgate Forum Discussion](https://forum.netgate.com/topic/200181/dnscrypt-proxy-package-available-full-gui-support) - Community discussion and support
+
+## Security
+
+This package vendors a third-party binary, so the release pipeline is built to
+keep that supply chain auditable:
+
+- **Upstream binaries are signature-verified** (minisign, against the official
+  DNSCrypt key) in CI before they are committed, and proposed via pull request
+  rather than auto-merged.
+- **Releases carry SLSA build provenance** plus a `SHA256SUMS` file. Verify a
+  download with `gh attestation verify <pkg> --repo nopoz/pfsense-dnscrypt-proxy`.
+- **Workflows are hardened**: Actions pinned to commit SHAs (kept current by
+  Dependabot), least-privilege tokens, and CI static analysis with ShellCheck,
+  `php -l`, actionlint, and zizmor.
+
+See [SECURITY.md](SECURITY.md) for the full policy and how to report a vulnerability.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported versions
+
+Only the [latest release](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
+is supported. Fixes are shipped as new releases rather than backported.
+
+## Reporting a vulnerability
+
+Please report security issues privately through GitHub's
+[**Report a vulnerability**](https://github.com/nopoz/pfsense-dnscrypt-proxy/security/advisories/new)
+flow (Security tab > Advisories) rather than opening a public issue.
+
+Expect an initial response within a few days. If a fix is warranted, it is
+released and the advisory is published once users have had time to update.
+
+## Supply-chain controls
+
+This package ships a third-party binary (`dnscrypt-proxy`) inside a `.pkg`, so
+the release pipeline is built to make that chain auditable:
+
+- **Upstream binary verification.** New upstream binaries are pulled and their
+  [minisign](https://jedisct1.github.io/minisign/) signatures verified against
+  the official DNSCrypt release key before they are ever committed. The update
+  is then proposed as a pull request for review, never auto-merged.
+  (`.github/workflows/upstream-update.yml`)
+- **Build provenance (SLSA).** Every release artifact is attested with
+  [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance),
+  cryptographically binding each `.pkg` to the workflow, commit, and runner that
+  produced it. A `SHA256SUMS` file is published alongside the artifacts.
+- **Pinned Actions.** All GitHub Actions are pinned to a full commit SHA, with
+  [Dependabot](.github/dependabot.yml) keeping the pins current.
+- **Least-privilege tokens.** Workflows default to no permissions and grant the
+  minimum scope each job needs.
+- **CI gates.** Pull requests run ShellCheck, `php -l`, actionlint, and
+  [zizmor](https://github.com/zizmorcore/zizmor) (GitHub Actions static
+  analysis) before merge. (`.github/workflows/ci.yml`)
+
+## Verifying a download
+
+Verify build provenance with the GitHub CLI:
+
+```bash
+gh attestation verify pfSense-pkg-dnscrypt-proxy-<version>.pkg \
+  --repo nopoz/pfsense-dnscrypt-proxy
+```
+
+Or check the published checksums:
+
+```bash
+# Download the package and SHA256SUMS from the same release, then:
+sha256sum -c SHA256SUMS
+```


### PR DESCRIPTION
## Summary

Adds a CI gate on pull requests and hardens the release supply chain. No build/runtime code changes; this is workflow + docs only.

## What changed

**New `ci.yml`** (runs on PRs and pushes to main)
- ShellCheck on all scripts (prints all findings, gates on error severity)
- `php -l` on every GUI/`.inc` PHP source
- actionlint (downloaded and checksum-verified before exec)
- zizmor, GitHub Actions static analysis
- Top-level `permissions: {}`, per-job least privilege, concurrency cancel-in-progress

**`release.yml` hardening**
- Pin `actions/checkout` and `actions/upload-artifact` to commit SHAs
- `persist-credentials: false`
- Default no permissions; job grants `contents`/`id-token`/`attestations: write`
- Concurrency guard
- Publish `SHA256SUMS`
- SLSA build provenance via `actions/attest-build-provenance` (verify with `gh attestation verify`)

**`upstream-update.yml`** — pin checkout SHA + `persist-credentials: false`

**`dependabot.yml`** — weekly `github-actions` updates to keep pinned digests current

**Docs** — `SECURITY.md` (policy, supply-chain controls, download verification) and a README security section + status badges

## Verification (run locally)
- zizmor: `No findings` (previously 3 high, 2 medium)
- actionlint: clean
- ShellCheck error gate: clean
- `php -l` on all 5 PHP files: clean