### PR TITLE
Cache release badge to avoid shields.io token-pool flaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pfSense DNSCrypt Proxy Package
 
 [![CI](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/v/release/nopoz/pfsense-dnscrypt-proxy?sort=semver)](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/nopoz/pfsense-dnscrypt-proxy?sort=semver&cacheSeconds=3600)](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
 [![Build provenance](https://img.shields.io/badge/build%20provenance-attested-success)](SECURITY.md#verifying-a-download)
 [![License: ISC](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
 


### PR DESCRIPTION
Append `cacheSeconds=3600` to the shields.io release badge URL.

The `github/v/release` badge calls the GitHub API via shields.io's shared token pool, which intermittently returns "Unable to select next GitHub token from pool" when rate-limited. Caching the value for an hour reduces how often the badge hits that window.