### PR TITLE
Revert release badge cacheSeconds that pinned shields error for an hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pfSense DNSCrypt Proxy Package
 
 [![CI](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/nopoz/pfsense-dnscrypt-proxy/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/v/release/nopoz/pfsense-dnscrypt-proxy?sort=semver&cacheSeconds=3600)](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/nopoz/pfsense-dnscrypt-proxy?sort=semver)](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest)
 [![Build provenance](https://img.shields.io/badge/build%20provenance-attested-success)](SECURITY.md#verifying-a-download)
 [![License: ISC](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
 


### PR DESCRIPTION
The earlier `cacheSeconds=3600` tweak backfired. Shields echoes `cacheSeconds` into the badge SVG's `Cache-Control`, and GitHub's Camo proxy honors it. During a shields token-pool flap the error response ("Unable to select next GitHub token from pool") got cached by Camo for a full hour instead of self-healing.

Verified with a browser: the rendered badge was 310px wide (the error string) and the Camo object carried `max-age=3600` expiring an hour out.

Reverting to the default ~5-minute TTL. Changing the URL also generates a new Camo hash, busting the currently stuck cached error.