### PR TITLE
fix: correct query log column mapping and add Relay column

### DIFF
--- a/files/usr/local/www/dnscrypt-proxy-querylog.php
+++ b/files/usr/local/www/dnscrypt-proxy-querylog.php
@@ -157,9 +157,10 @@ display_top_tabs($tab_array);
 						<th><?=gettext("Client")?></th>
 						<th><?=gettext("Domain")?></th>
 						<th><?=gettext("Type")?></th>
-						<th><?=gettext("Server")?></th>
-						<th><?=gettext("Latency")?></th>
 						<th><?=gettext("Status")?></th>
+						<th><?=gettext("Latency")?></th>
+						<th><?=gettext("Server")?></th>
+						<th><?=gettext("Relay")?></th>
 					</tr>
 				</thead>
 				<tbody>
@@ -180,7 +181,7 @@ if (file_exists($query_log_file) && is_readable($query_log_file)) {
 			}
 
 			// Parse dnscrypt-proxy query log format (tab-separated)
-			// Format: timestamp	client_ip	query_name	query_type	resolver	latency_ms	status
+			// Format: timestamp	client_ip	query_name	query_type	return_code	duration	server	relay
 			$parts = explode("\t", $line);
 
 			if (count($parts) >= 6) {
@@ -189,9 +190,10 @@ if (file_exists($query_log_file) && is_readable($query_log_file)) {
 					'client' => $parts[1] ?? '',
 					'domain' => $parts[2] ?? '',
 					'type' => $parts[3] ?? '',
-					'server' => $parts[4] ?? '',
+					'status' => $parts[4] ?? '',
 					'latency' => $parts[5] ?? '',
-					'status' => $parts[6] ?? 'OK'
+					'server' => $parts[6] ?? '',
+					'relay' => $parts[7] ?? ''
 				);
 
 				// Apply filters
@@ -214,7 +216,7 @@ if (file_exists($query_log_file) && is_readable($query_log_file)) {
 
 if (empty($entries)): ?>
 					<tr>
-						<td colspan="7" class="text-center text-muted">
+						<td colspan="8" class="text-center text-muted">
 							<?php if (!file_exists($query_log_file)): ?>
 								<?=gettext("Query log file does not exist. Enable query logging and make some DNS queries.")?>
 							<?php else: ?>
@@ -224,17 +226,24 @@ if (empty($entries)): ?>
 					</tr>
 <?php else:
 	foreach ($entries as $entry):
-		$status_class = (stripos($entry['status'], 'PASS') !== false || $entry['status'] == 'OK') ? 'success' :
-		               ((stripos($entry['status'], 'BLOCK') !== false || stripos($entry['status'], 'REJECT') !== false) ? 'danger' : 'default');
+		// dnscrypt-proxy return codes, grouped by how they should read at a glance
+		$status_classes = array(
+			'PASS' => 'success', 'FORWARD' => 'success',
+			'REJECT' => 'danger', 'DROP' => 'danger', 'SYNTH' => 'danger', 'CLOAK' => 'danger',
+			'PARSE_ERROR' => 'warning', 'RESPONSE_ERROR' => 'warning',
+			'SERVER_ERROR' => 'warning', 'SERVER_TIMEOUT' => 'warning'
+		);
+		$status_class = $status_classes[strtoupper($entry['status'])] ?? 'default';
 ?>
 					<tr>
 						<td><?=htmlspecialchars($entry['time'])?></td>
 						<td><?=htmlspecialchars($entry['client'])?></td>
 						<td><code><?=htmlspecialchars($entry['domain'])?></code></td>
 						<td><span class="label label-primary"><?=htmlspecialchars($entry['type'])?></span></td>
-						<td><?=htmlspecialchars($entry['server'])?></td>
-						<td><?=htmlspecialchars($entry['latency'])?></td>
 						<td><span class="label label-<?=htmlspecialchars($status_class)?>"><?=htmlspecialchars($entry['status'])?></span></td>
+						<td><?=htmlspecialchars($entry['latency'])?></td>
+						<td><?=htmlspecialchars($entry['server'])?></td>
+						<td><?=htmlspecialchars($entry['relay'])?></td>
 					</tr>
 <?php
 	endforeach;


### PR DESCRIPTION
Fixes #31, reported by @jccairns.

## Problem

The Query Log page parsed the log with field indices for a guessed 7-column format. dnscrypt-proxy's TSV format is 8 columns:

```
timestamp  client_ip  query_name  query_type  return_code  duration  server  relay
```

So `$parts[4]` (return_code) was rendered under the **Server** header, `$parts[6]` (server) was rendered under **Status**, and `$parts[7]` (relay) was never read at all.

Real line from a live box, showing the off-by-two:

```
[2026-07-24 13:32:04]  10.0.0.1  api.github.com  A  PASS  36ms  quad9-dnscrypt-ip4-filter-ecs-pri  dnscry.pt-anon-vancouver-ipv4
   0                      1           2          3    4     5      6                                  7
```

## Changes

- Correct the index mapping and the format comment
- Add the missing **Relay** column, ordering headers to match the log's own field order (Time, Client, Domain, Type, Status, Latency, Server, Relay)
- Bump the empty-state `colspan` from 7 to 8
- Replace the status badge classifier. It matched `PASS`/`OK`/`BLOCK`/`REJECT`, which never fired because that column actually held server names. Now that real return codes land there, it maps the codes dnscrypt-proxy emits: `PASS`/`FORWARD` green, `REJECT`/`DROP`/`SYNTH`/`CLOAK` red, `PARSE_ERROR`/`RESPONSE_ERROR`/`SERVER_ERROR`/`SERVER_TIMEOUT` amber.

## Testing

- `php -l` clean, both locally and under the pfSense box's PHP
- Rendered the page against 95 real log lines from a live pfSense box. Every field lands under its labeled header: Relay shows the anonymized relay name where anonymized DNS is in use and `-` otherwise; `PASS` renders green, `SYNTH` red.
- Fed it a truncated 6-field line: renders with empty Server/Relay, no PHP diagnostics under `E_ALL`
- Confirmed working in the actual GUI on a live pfSense 2.8.1 box

## Note on the reported patch

The patch in #31 defaulted `server` to `'OK'` (carried over from the old `status` default) and `relay` to `'N/A'`. This uses empty strings for both, since dnscrypt-proxy already writes `-` for an unused relay and a second placeholder would render inconsistently.