### PR TITLE
Fetch dnscrypt-proxy from upstream releases instead of bundling it

### DIFF
--- a/.github/workflows/ports-check.yml
+++ b/.github/workflows/ports-check.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Stage port into a ports tree and check it
-        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d  # v1.5.2
+        uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093  # v1.5.3
         with:
           usesh: true
           release: "15.0"

--- a/.github/workflows/ports-check.yml
+++ b/.github/workflows/ports-check.yml
@@ -5,8 +5,9 @@ name: Ports check
 # run it: the dev machine is Linux, and the pfSense box has no ports tree.
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}
@@ -48,6 +49,18 @@ jobs:
             for f in Makefile pkg-descr pkg-plist distinfo; do
               [ -f "${WS}/${f}" ] && cp "${WS}/${f}" "${PORTDIR}/"
             done
+
+            # sync-ports.yml excludes the bundled binaries from what actually
+            # reaches the ports tree. Mirror that here so this gate builds
+            # what sync ships, not a superset of it.
+            BUNDLED_DIR="${PORTDIR}/files/usr/local/bin/dnscrypt-proxy-bin"
+            rm -rf "${BUNDLED_DIR}"
+
+            # Assert the invariant: no bundled binaries reach the ports tree.
+            if find "${BUNDLED_DIR}" -mindepth 1 2>/dev/null | grep -q .; then
+              echo "::error::Bundled binaries still present under ${BUNDLED_DIR}" >&2
+              exit 1
+            fi
 
             cd "${PORTDIR}"
             make check-plist

--- a/.github/workflows/ports-check.yml
+++ b/.github/workflows/ports-check.yml
@@ -1,0 +1,53 @@
+name: Ports check
+
+# Builds the port the way the FreeBSD ports framework will, and checks the
+# plist against what actually gets staged. This is the only place that can
+# run it: the dev machine is Linux, and the pfSense box has no ports tree.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    name: make check-plist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Stage port into a ports tree and check it
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d  # v1.5.2
+        with:
+          usesh: true
+          release: "15.0"
+          run: |
+            set -e
+            WS=$(pwd)
+            pkg install -y git
+
+            # The pfSense ports tree is 169k files and 2.7 GB of history.
+            # Take only the framework directories plus our package dir.
+            git clone --depth 1 --filter=blob:none --no-checkout --single-branch \
+              --branch devel https://github.com/pfsense/FreeBSD-ports.git /usr/ports
+            cd /usr/ports
+            git sparse-checkout init --cone
+            git sparse-checkout set Mk Templates Keywords dns/pfSense-pkg-dnscrypt-proxy
+            git checkout devel
+
+            # Overlay this repo's port definition.
+            PORTDIR=/usr/ports/dns/pfSense-pkg-dnscrypt-proxy
+            rm -rf "${PORTDIR}"
+            mkdir -p "${PORTDIR}"
+            cp -R "${WS}/files" "${PORTDIR}/files"
+            for f in Makefile pkg-descr pkg-plist distinfo; do
+              [ -f "${WS}/${f}" ] && cp "${WS}/${f}" "${PORTDIR}/"
+            done
+
+            cd "${PORTDIR}"
+            make check-plist

--- a/.github/workflows/sync-ports.yml
+++ b/.github/workflows/sync-ports.yml
@@ -4,7 +4,8 @@ name: Sync to FreeBSD-ports
 # fork, which is the head of upstream PR pfsense/FreeBSD-ports#1434.
 #
 # The ports fork is derived, never authored. Nothing there is edited by hand:
-# this workflow copies Makefile, pkg-descr, pkg-plist and files/ into
+# this workflow copies Makefile, pkg-descr, pkg-plist, distinfo and files/
+# (minus the bundled binaries) into
 # dns/pfSense-pkg-dnscrypt-proxy, amends the branch's single squashed commit,
 # and force-pushes, which updates the open PR in place.
 #
@@ -110,9 +111,14 @@ jobs:
 
           # --delete so that removing a file here removes it there. A plain
           # copy leaves deleted files behind in the PR forever.
-          rsync -a --delete pkg/files/ "${TARGET}/files/"
+          # The bundled binaries stay in this repo for the standalone .pkg
+          # build. The port fetches the daemon from upstream instead, so they
+          # must never reach the ports tree. --delete removes them from the
+          # target if an earlier sync put them there.
+          rsync -a --delete --exclude 'usr/local/bin/dnscrypt-proxy-bin/' \
+            pkg/files/ "${TARGET}/files/"
 
-          for f in Makefile pkg-descr pkg-plist; do
+          for f in Makefile pkg-descr pkg-plist distinfo; do
             install -m 0644 "pkg/${f}" "${TARGET}/${f}"
           done
 

--- a/.github/workflows/sync-ports.yml
+++ b/.github/workflows/sync-ports.yml
@@ -162,6 +162,12 @@ jobs:
           # Feed the token through a credential helper rather than embedding it
           # in the remote URL or a command argument, so it never lands in
           # .git/config, the process table, or the run log.
+          #
+          # The single quotes are the whole point: ${PORTS_SYNC_TOKEN} must be
+          # stored literally and expanded by sh when git invokes the helper at
+          # push time. Expanding it here would write the token into
+          # .git/config, which is exactly what this avoids.
+          # shellcheck disable=SC2016
           git config credential.helper '!f() { echo username=x-access-token; echo "password=${PORTS_SYNC_TOKEN}"; }; f'
 
           git push --force-with-lease origin "HEAD:${PORTS_BRANCH}"

--- a/.github/workflows/sync-ports.yml
+++ b/.github/workflows/sync-ports.yml
@@ -130,6 +130,7 @@ jobs:
           find "${TARGET}" -type f | sort
 
       - name: Amend branch commit and push
+        id: push
         env:
           VERSION: ${{ steps.version.outputs.version }}
           PORTS_SYNC_TOKEN: ${{ secrets.PORTS_SYNC_TOKEN }}
@@ -170,6 +171,7 @@ jobs:
         if: always()
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
         run: |
           {
             echo "### Ports sync"
@@ -178,6 +180,8 @@ jobs:
               echo "Pushed \`v${VERSION}\` to \`${PORTS_REPO}\` branch \`${PORTS_BRANCH}\`."
               echo
               echo "PR: https://github.com/pfsense/FreeBSD-ports/pull/1434"
+            elif [ "${PUSH_OUTCOME}" = "failure" ]; then
+              echo "Sync failed: the push step did not complete. See job logs."
             else
               echo "No changes to push for \`v${VERSION}\`."
             fi

--- a/.github/workflows/sync-ports.yml
+++ b/.github/workflows/sync-ports.yml
@@ -1,0 +1,178 @@
+name: Sync to FreeBSD-ports
+
+# Projects this repo onto the ports-tree layout carried by the FreeBSD-ports
+# fork, which is the head of upstream PR pfsense/FreeBSD-ports#1434.
+#
+# The ports fork is derived, never authored. Nothing there is edited by hand:
+# this workflow copies Makefile, pkg-descr, pkg-plist and files/ into
+# dns/pfSense-pkg-dnscrypt-proxy, amends the branch's single squashed commit,
+# and force-pushes, which updates the open PR in place.
+#
+# Replaces the local sync-to-ports.sh, which was gitignored, machine-specific,
+# and had to be remembered. It was not, and the fork drifted five versions.
+#
+# Triggering on the release tag rather than on push to main is deliberate: the
+# PR should show a released version, not work in progress. This runs alongside
+# release.yml rather than after it, because the ports tree builds the package
+# itself in poudriere, so a failed .pkg build does not invalidate the sources.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to sync (e.g. 1.2.9)'
+        required: true
+
+# Default to no privileges. This job needs none against *this* repo; writing to
+# the ports fork is authorised by PORTS_SYNC_TOKEN, not by GITHUB_TOKEN.
+permissions: {}
+
+# Never let two runs force-push the same branch at once.
+concurrency:
+  group: sync-ports
+  cancel-in-progress: false
+
+env:
+  PORTS_REPO: nopoz/FreeBSD-ports
+  PORTS_BRANCH: dnscrypt
+  PKG_SUBDIR: dns/pfSense-pkg-dnscrypt-proxy
+
+jobs:
+  sync:
+    name: Project onto ports tree
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout package repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          path: pkg
+          persist-credentials: false
+
+      - name: Resolve and validate version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+
+          # Anchor to a plain dotted release before the value reaches a commit
+          # message or a shell. Same guard as release.yml, for the same reason.
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '${VERSION}'. Expected MAJOR.MINOR.PATCH." >&2
+            exit 1
+          fi
+
+          # Refuse to sync a tag that does not match the Makefile at that
+          # commit. Without this the ports PR can advertise a version whose
+          # sources are something else entirely.
+          MK=$(grep '^PORTVERSION=' pkg/Makefile | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ "${VERSION}" != "${MK}" ]; then
+            echo "::error::Version ${VERSION} does not match Makefile PORTVERSION ${MK} at this commit." >&2
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Syncing version ${VERSION}"
+
+      # The ports tree is ~169k files and 2.7 GB of history. Clone only what
+      # this job touches: blobless, single branch, sparse to the one package
+      # directory. fetch-depth 2 rather than 1 so the parent of the branch tip
+      # is a real local object, which keeps `commit --amend` and the subsequent
+      # push out of shallow-clone edge cases.
+      - name: Checkout ports fork (sparse)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: ${{ env.PORTS_REPO }}
+          ref: ${{ env.PORTS_BRANCH }}
+          token: ${{ secrets.PORTS_SYNC_TOKEN }}
+          path: ports
+          fetch-depth: 2
+          filter: blob:none
+          sparse-checkout: ${{ env.PKG_SUBDIR }}
+          persist-credentials: false
+
+      - name: Sync package files
+        run: |
+          set -euo pipefail
+          TARGET="ports/${PKG_SUBDIR}"
+          mkdir -p "${TARGET}"
+
+          # --delete so that removing a file here removes it there. A plain
+          # copy leaves deleted files behind in the PR forever.
+          rsync -a --delete pkg/files/ "${TARGET}/files/"
+
+          for f in Makefile pkg-descr pkg-plist; do
+            install -m 0644 "pkg/${f}" "${TARGET}/${f}"
+          done
+
+          # build/ holds generated artifacts and must never reach the ports
+          # tree, whether or not it was ever committed there.
+          rm -rf "${TARGET:?}/build"
+
+          echo "=== synced tree ==="
+          find "${TARGET}" -type f | sort
+
+      - name: Amend branch commit and push
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PORTS_SYNC_TOKEN: ${{ secrets.PORTS_SYNC_TOKEN }}
+        working-directory: ports
+        run: |
+          set -euo pipefail
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git add -A -- "${PKG_SUBDIR}"
+
+          if git diff --cached --quiet; then
+            echo "Ports fork already matches v${VERSION}. Nothing to push."
+            echo "PUSHED=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "=== changes to be pushed ==="
+          git diff --cached --stat
+
+          # The PR is deliberately a single squashed commit. Amend it rather
+          # than adding to it, so the upstream diff stays reviewable as one
+          # "add new package" change.
+          git commit --amend -m "${PKG_SUBDIR}: add new package v${VERSION}
+
+          Synced from the standalone repository at v${VERSION}."
+
+          # Feed the token through a credential helper rather than embedding it
+          # in the remote URL or a command argument, so it never lands in
+          # .git/config, the process table, or the run log.
+          git config credential.helper '!f() { echo username=x-access-token; echo "password=${PORTS_SYNC_TOKEN}"; }; f'
+
+          git push --force-with-lease origin "HEAD:${PORTS_BRANCH}"
+          echo "PUSHED=true" >> "$GITHUB_ENV"
+
+      - name: Summary
+        if: always()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "### Ports sync"
+            echo
+            if [ "${PUSHED:-false}" = "true" ]; then
+              echo "Pushed \`v${VERSION}\` to \`${PORTS_REPO}\` branch \`${PORTS_BRANCH}\`."
+              echo
+              echo "PR: https://github.com/pfsense/FreeBSD-ports/pull/1434"
+            else
+              echo "No changes to push for \`v${VERSION}\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upstream-update.yml
+++ b/.github/workflows/upstream-update.yml
@@ -99,6 +99,25 @@ jobs:
             install -m 0755 "${WORK}/freebsd-${ARCH}/dnscrypt-proxy" "${DEST}/dnscrypt-proxy-${ARCH}"
           done
 
+          # Regenerate distinfo from the very tarballs just verified above.
+          # This is how minisign provenance reaches the ports tree: the
+          # checksums recorded here are computed from signed artifacts.
+          {
+            echo "TIMESTAMP = $(date +%s)"
+            for ARCH in amd64 arm64; do
+              TARBALL="dnscrypt-proxy-freebsd_${ARCH}-${VER}.tar.gz"
+              echo "SHA256 (${TARBALL}) = $(sha256sum "${WORK}/${TARBALL}" | cut -d' ' -f1)"
+              echo "SIZE (${TARBALL}) = $(stat -c %s "${WORK}/${TARBALL}")"
+            done
+          } > distinfo
+
+          # Point the port at the new daemon version.
+          sed -i "s/^DNSCRYPT_VERSION=.*/DNSCRYPT_VERSION=\t${VER}/" Makefile
+          if ! grep -q "^DNSCRYPT_VERSION=	${VER}$" Makefile; then
+            echo "Failed to update DNSCRYPT_VERSION in Makefile" >&2
+            exit 1
+          fi
+
           # Bump the package patch version (1.2.4 -> 1.2.5). Read only the
           # PORTVERSION line so an unrelated version string elsewhere in the
           # Makefile can't be picked up by mistake.
@@ -139,6 +158,7 @@ jobs:
             - Bundled binary: `${{ steps.versions.outputs.current }}` -> `${{ steps.versions.outputs.latest }}` (amd64 + arm64)
             - Package version: bumped to `${{ env.NEWPKG }}`
             - Minisign signatures verified against the official release key.
+            - `distinfo` regenerated from the verified tarballs, and `DNSCRYPT_VERSION` bumped in `Makefile`.
 
             **To release:** review and merge this PR, then push a tag:
             ```

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PORTNAME=	pfSense-pkg-dnscrypt-proxy
 PORTVERSION=	1.2.9
 CATEGORIES=	dns
 
-MAINTAINER=	ports@FreeBSD.org
+MAINTAINER=	bill.lowney@gmail.com
 COMMENT=	pfSense package for DNSCrypt Proxy encrypted DNS client
 
 LICENSE=	ISCL

--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,51 @@
 PORTNAME=	pfSense-pkg-dnscrypt-proxy
 PORTVERSION=	1.2.9
 CATEGORIES=	dns
-MASTER_SITES=	# empty
-DISTFILES=	# empty
-EXTRACT_ONLY=	# empty
 
 MAINTAINER=	ports@FreeBSD.org
 COMMENT=	pfSense package for DNSCrypt Proxy encrypted DNS client
 
-LICENSE=	ISC
+LICENSE=	ISCL
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+# The daemon is not built here: upstream publishes signed, statically linked
+# FreeBSD binaries per release, and they are fetched and checksum-pinned by
+# distinfo rather than committed to the tree.
+DNSCRYPT_VERSION=	2.1.18
+MASTER_SITES=	https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/${DNSCRYPT_VERSION}/
+
+ONLY_FOR_ARCHS=	amd64 aarch64
 
 NO_BUILD=	yes
 NO_MTREE=	yes
 
+# dns/dnscrypt-proxy2 installs sbin/dnscrypt-proxy. No plist collision, but two
+# copies of the daemon and two services is not a supported configuration.
+CONFLICTS_INSTALL=	dnscrypt-proxy2
+
 SUB_FILES=	pkg-install pkg-deinstall
 SUB_LIST=	PORTNAME=${PORTNAME}
 
-do-extract:
-	${MKDIR} ${WRKSRC}
+.include <bsd.port.pre.mk>
+
+# FreeBSD calls it aarch64; upstream names the asset arm64.
+.if ${ARCH} == aarch64
+DNSCRYPT_ARCH=	arm64
+.else
+DNSCRYPT_ARCH=	${ARCH}
+.endif
+
+DISTFILES=	dnscrypt-proxy-freebsd_${DNSCRYPT_ARCH}-${DNSCRYPT_VERSION}${EXTRACT_SUFX}
+WRKSRC=		${WRKDIR}/freebsd-${DNSCRYPT_ARCH}
 
 do-install:
+	${MKDIR} ${STAGEDIR}${PREFIX}/bin
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg
-	${MKDIR} ${STAGEDIR}${PREFIX}/bin/dnscrypt-proxy-bin
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
 	${MKDIR} ${STAGEDIR}${DATADIR}
 	${MKDIR} ${STAGEDIR}/etc/inc/priv
+	${INSTALL_PROGRAM} ${WRKSRC}/dnscrypt-proxy \
+		${STAGEDIR}${PREFIX}/bin/dnscrypt-proxy
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/dnscrypt-proxy.inc \
 		${STAGEDIR}${PREFIX}/pkg
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/pkg/dnscrypt-proxy.xml \
@@ -53,13 +74,7 @@ do-install:
 		${STAGEDIR}${PREFIX}/www/shortcuts
 	${INSTALL_DATA} ${FILESDIR}/etc/inc/priv/dnscrypt-proxy.priv.inc \
 		${STAGEDIR}/etc/inc/priv
-	${INSTALL_DATA} ${FILESDIR}${PREFIX}/bin/dnscrypt-proxy-bin/LICENSE \
-		${STAGEDIR}${PREFIX}/bin/dnscrypt-proxy-bin
-	${INSTALL_PROGRAM} ${FILESDIR}${PREFIX}/bin/dnscrypt-proxy-bin/dnscrypt-proxy-amd64 \
-		${STAGEDIR}${PREFIX}/bin/dnscrypt-proxy-bin
-	${INSTALL_PROGRAM} ${FILESDIR}${PREFIX}/bin/dnscrypt-proxy-bin/dnscrypt-proxy-arm64 \
-		${STAGEDIR}${PREFIX}/bin/dnscrypt-proxy-bin
 	@${REINPLACE_CMD} -i '' -e "s|%%PKGVERSION%%|${PKGVERSION}|" \
 		${STAGEDIR}${DATADIR}/info.xml
 
-.include <bsd.port.mk>
+.include <bsd.port.post.mk>

--- a/distinfo
+++ b/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1786737215
+SHA256 (dnscrypt-proxy-freebsd_amd64-2.1.18.tar.gz) = 843ab6129bd7692b2f77ead2f3de1c7951d55258d3c542034c5d15be2b13f9ea
+SIZE (dnscrypt-proxy-freebsd_amd64-2.1.18.tar.gz) = 4694109
+SHA256 (dnscrypt-proxy-freebsd_arm64-2.1.18.tar.gz) = 7b198f662ac3602e914ff6c3764ef5d37dc674ef5bdd4b3231f8827cc759bcc8
+SIZE (dnscrypt-proxy-freebsd_arm64-2.1.18.tar.gz) = 4209599

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -869,7 +869,12 @@ function dnscrypt_proxy_deinstall() {
 	}
 
 	// Remove files
-	unlink_if_exists(DNSCRYPT_PROXY_BINARY);
+	// The binary is only ours to remove for the standalone package, which
+	// installed it itself. In the ports distribution, pkg owns the binary
+	// via pkg-plist and removes it on its own.
+	if (is_dir(DNSCRYPT_PROXY_BUNDLED_DIR)) {
+		unlink_if_exists(DNSCRYPT_PROXY_BINARY);
+	}
 	unlink_if_exists(DNSCRYPT_PROXY_RCFILE);
 	unlink_if_exists(DNSCRYPT_PROXY_CONFIG);
 	unlink_if_exists(DNSCRYPT_PROXY_BASE . '/blocked-names.txt');

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -779,6 +779,13 @@ function dnscrypt_proxy_install() {
  * Install the bundled dnscrypt-proxy binary for the current architecture
  */
 function dnscrypt_proxy_install_binary() {
+	// The ports build installs the daemon straight to DNSCRYPT_PROXY_BINARY
+	// from an upstream distfile, so there is no bundled directory to copy
+	// from. Absence is the normal case there, not a failure.
+	if (!is_dir(DNSCRYPT_PROXY_BUNDLED_DIR)) {
+		return true;
+	}
+
 	// Detect architecture
 	$arch = php_uname('m');
 	if ($arch == 'amd64' || $arch == 'x86_64') {

--- a/pkg-plist
+++ b/pkg-plist
@@ -1,7 +1,5 @@
 /etc/inc/priv/dnscrypt-proxy.priv.inc
-bin/dnscrypt-proxy-bin/LICENSE
-bin/dnscrypt-proxy-bin/dnscrypt-proxy-amd64
-bin/dnscrypt-proxy-bin/dnscrypt-proxy-arm64
+bin/dnscrypt-proxy
 pkg/dnscrypt-proxy.inc
 pkg/dnscrypt-proxy.xml
 pkg/dnscrypt-proxy-advanced.xml
@@ -11,8 +9,8 @@ pkg/dnscrypt-proxy-logging.xml
 pkg/dnscrypt-proxy-querylog.xml
 pkg/dnscrypt-proxy-servers.xml
 %%DATADIR%%/info.xml
+www/dnscrypt-proxy-config.php
 www/dnscrypt-proxy-querylog.php
 www/shortcuts/pkg_dnscrypt-proxy.inc
-@dir bin/dnscrypt-proxy-bin
 @dir /etc/inc/priv
 @dir /etc/inc


### PR DESCRIPTION
Reworks the FreeBSD port so it fetches upstream's released FreeBSD binaries as distfiles pinned by `distinfo`, instead of committing them into the ports tree. This answers the review comment on pfsense/FreeBSD-ports#1434.

The standalone `.pkg` build is unchanged and still bundles the binaries from `files/`. A single `dnscrypt-proxy.inc` serves both, which is why the daemon installs to the same path in each.

## Changes

- `Makefile`: `MASTER_SITES` at the upstream release URL, per-arch `DISTFILES`, `ONLY_FOR_ARCHS= amd64 aarch64`, `WRKSRC` pointing into the extracted tarball, `CONFLICTS_INSTALL= dnscrypt-proxy2`. Removes the `do-extract:` override, which existed only because the port had no distfiles and would otherwise leave `WRKSRC` empty.
- `distinfo`: new, pinning SHA256 and SIZE for both architectures at 2.1.18.
- `pkg-plist`: adds `bin/dnscrypt-proxy`, drops the four bundled-binary entries.
- `dnscrypt-proxy.inc`: the bundled-binary install and the deinstall unlink are now guarded on the bundled directory existing, so the ports build leaves the binary to pkg, which owns it via the plist.
- `sync-ports.yml`: new, projects this repo onto the ports fork on release tag. Excludes the bundled binaries, which takes the projection from about 25 MB to 224 KB.
- `ports-check.yml`: new, stages the port into a real sparse checkout of the pfSense ports tree in a FreeBSD VM and runs `make check-plist`.
- `upstream-update.yml`: regenerates `distinfo` from the tarballs it already minisign-verifies, and bumps `DNSCRYPT_VERSION`.

## Incidental fixes the new CI caught

- `LICENSE` was `ISC`, which is not a license code the ports framework knows. The build aborted in `bsd.licenses.mk` before staging. Now `ISCL`, matching `dns/dnscrypt-proxy2`.
- `pkg-plist` never listed `www/dnscrypt-proxy-config.php`, although `do-install` has always staged it. `make check-plist` flags it as an orphan.
- `MAINTAINER` was the `ports@FreeBSD.org` catch-all, which is the framework default and reads as unmaintained.

## Verification

`make check-plist` passes against a real ports tree. On a live pfSense 2.8.1 box, the pinned checksum matches when the tarball is fetched on FreeBSD, the binary reports 2.1.18, and `dnscrypt_proxy_get_version()` reads the version from the binary at runtime rather than a compiled-in constant.