### PR TITLE
Actually delete the bundled binaries from the ports projection

### DIFF
--- a/.github/workflows/sync-ports.yml
+++ b/.github/workflows/sync-ports.yml
@@ -111,12 +111,26 @@ jobs:
 
           # --delete so that removing a file here removes it there. A plain
           # copy leaves deleted files behind in the PR forever.
+          #
           # The bundled binaries stay in this repo for the standalone .pkg
           # build. The port fetches the daemon from upstream instead, so they
-          # must never reach the ports tree. --delete removes them from the
-          # target if an earlier sync put them there.
-          rsync -a --delete --exclude 'usr/local/bin/dnscrypt-proxy-bin/' \
+          # must never reach the ports tree.
+          #
+          # --delete-excluded is load-bearing, not decoration. On its own,
+          # --exclude PROTECTS matching files already in the destination from
+          # --delete, so an --exclude/--delete pair leaves previously synced
+          # binaries sitting in the fork forever. Only --delete-excluded
+          # removes them. This is invisible when syncing into an empty
+          # directory, which is why it survived a local dry run.
+          rsync -a --delete --delete-excluded \
+            --exclude 'usr/local/bin/dnscrypt-proxy-bin/' \
             pkg/files/ "${TARGET}/files/"
+
+          # Assert it, rather than trusting the flag combination.
+          if find "${TARGET}/files" -name 'dnscrypt-proxy-*64' -print -quit | grep -q .; then
+            echo "::error::Bundled binaries reached the ports projection" >&2
+            exit 1
+          fi
 
           for f in Makefile pkg-descr pkg-plist distinfo; do
             install -m 0644 "pkg/${f}" "${TARGET}/${f}"


### PR DESCRIPTION
The previous sync ran and reported success, but the binaries were still in the fork afterwards.

`rsync --exclude` protects matching files that already exist in the destination from `--delete`. So `--delete --exclude <dir>` copies nothing new into that directory but also refuses to remove what is already there. `--delete-excluded` is what removes it.

This was invisible in the local dry run because that ran against an empty destination, where excluded-and-absent and excluded-and-deleted look identical. The real fork already contained the binaries from an earlier sync.

Adds `--delete-excluded` and asserts the outcome rather than trusting the flag combination.