### PR TITLE
Survive pfSense OS upgrades, and warn when removal will break DNS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
 
             ### Uninstall
             ```bash
-            pkg delete pfSense-pkg-dnscrypt-proxy
+            pkg delete -f pfSense-pkg-dnscrypt-proxy
             ```
 
             See [README](https://github.com/${{ github.repository }}#readme) for full documentation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,12 @@ jobs:
 
             ### pfSense CE
             ```bash
-            pkg-static add https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/pfSense-pkg-dnscrypt-proxy-${{ steps.version.outputs.version }}.pkg
+            pkg-static add -A https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/pfSense-pkg-dnscrypt-proxy-${{ steps.version.outputs.version }}.pkg
             ```
 
             ### pfSense Plus
             ```bash
-            pkg-static -C /dev/null add https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/pfSense-pkg-dnscrypt-proxy-${{ steps.version.outputs.version }}.pkg
+            pkg-static -C /dev/null add -A https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/pfSense-pkg-dnscrypt-proxy-${{ steps.version.outputs.version }}.pkg
             ```
 
             ### Uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-dnscrypt-proxy
-PORTVERSION=	1.2.9
+PORTVERSION=	1.2.10
 CATEGORIES=	dns
 
 MAINTAINER=	bill.lowney@gmail.com

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ itself automatic (see `-A` above) precisely so that loop skips it rather than
 stopping on it.
 
 The package is left installed with its settings gone from `config.xml`, so it
-disappears from **Services** while its daemon keeps running from the previous
-configuration. Remove it explicitly if you want a clean box:
+disappears from **Services**. The daemon will not start in that state, so
+nothing is left running, but the package files remain. Remove it explicitly if
+you want a clean box:
 
 ```bash
 pkg delete -f pfSense-pkg-dnscrypt-proxy

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ pkg-static add -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/lates
 
 Your configuration settings are preserved during upgrades.
 
+### Factory Defaults reset
+
+A Factory Defaults reset will **not** remove this package. pfSense removes
+add-on packages by looping over manually installed ones, and this package marks
+itself automatic (see `-A` above) precisely so that loop skips it rather than
+stopping on it.
+
+The package is left installed with its settings gone from `config.xml`, so it
+disappears from **Services** while its daemon keeps running from the previous
+configuration. Remove it explicitly if you want a clean box:
+
+```bash
+pkg delete -f pfSense-pkg-dnscrypt-proxy
+```
+
 ### Upgrading pfSense itself
 
 Upgrading pfSense (2.8.1 to 2.9.0, for example) deletes every package that is

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Run this command in the pfSense shell (via SSH or Console):
 ### pfSense CE
 
 ```bash
-pkg-static add https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
+pkg-static add -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
 ```
 
 ### pfSense Plus
 
 ```bash
-pkg-static -C /dev/null add https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
+pkg-static -C /dev/null add -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
 ```
 
 ### Installing a Specific Version
@@ -76,7 +76,7 @@ pkg-static -C /dev/null add https://github.com/nopoz/pfsense-dnscrypt-proxy/rele
 Replace `latest/download/pfSense-pkg-dnscrypt-proxy.pkg` with `download/vX.X.X/pfSense-pkg-dnscrypt-proxy-X.X.X.pkg`:
 
 ```bash
-pkg-static add https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/download/v1.0.0/pfSense-pkg-dnscrypt-proxy-1.0.0.pkg
+pkg-static add -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/download/v1.0.0/pfSense-pkg-dnscrypt-proxy-1.0.0.pkg
 ```
 
 See all available versions on the [Releases](https://github.com/nopoz/pfsense-dnscrypt-proxy/releases) page.
@@ -85,19 +85,30 @@ After installation, navigate to **Services > DNSCrypt Proxy** in the pfSense web
 
 > **Note:** This package won't appear under "Installed Packages" since it's installed manually, not from the pfSense repository. It will appear under **Services > DNSCrypt Proxy**, on the Dashboard under **Services Status**, and under **Status > Services**.
 
+> **Why `-A`?** It marks the package automatically installed, which is not
+> cosmetic here. pfSense's bulk package operations, Factory Defaults reset and
+> "Reinstall all packages", loop over manually installed packages only and stop
+> at the first one they cannot find in the pfSense repository. A package
+> installed from a file is never in that repository, so without `-A` those
+> operations abort partway and silently leave every package sorting after this
+> one untouched. With `-A` they skip this package and finish normally. It does
+> not risk the package being auto-removed, because the package also marks
+> itself vital. If you installed without `-A`, run
+> `pkg set -A 1 pfSense-pkg-dnscrypt-proxy` once.
+
 ### Upgrading
 
 To upgrade to a newer version, use the `-f` (force) flag:
 
 ```bash
-pkg-static add -f https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
+pkg-static add -f -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
 ```
 
 Or delete the existing package first, then install the new version:
 
 ```bash
 pkg delete -f pfSense-pkg-dnscrypt-proxy
-pkg-static add https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
+pkg-static add -A https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
 ```
 
 Your configuration settings are preserved during upgrades.
@@ -175,9 +186,11 @@ pkg delete -f pfSense-pkg-dnscrypt-proxy
 The `-f` is required because the package marks itself vital so that a pfSense
 OS upgrade cannot delete it (see [Upgrading pfSense
 itself](#upgrading-pfsense-itself)). It only bypasses that check, so the
-uninstall is otherwise normal and still runs the package's own cleanup. If you
-prefer, `pkg set -v 0 pfSense-pkg-dnscrypt-proxy` first and then plain `pkg
-delete` does the same thing.
+uninstall is otherwise normal and still runs the package's own cleanup.
+
+Use `-f` rather than clearing the vital flag by hand. `pkg set -v 0` leaves the
+package marked automatic but no longer protected, and the next `pkg autoremove`
+will then delete it without warning.
 
 ### Complete Removal (Troubleshooting)
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,34 @@ pkg-static add -f https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/lates
 Or delete the existing package first, then install the new version:
 
 ```bash
-pkg delete pfSense-pkg-dnscrypt-proxy
+pkg delete -f pfSense-pkg-dnscrypt-proxy
 pkg-static add https://github.com/nopoz/pfsense-dnscrypt-proxy/releases/latest/download/pfSense-pkg-dnscrypt-proxy.pkg
 ```
 
 Your configuration settings are preserved during upgrades.
+
+### Upgrading pfSense itself
+
+Upgrading pfSense (2.8.1 to 2.9.0, for example) deletes every package that is
+not in the official pfSense repository. This is deliberate behaviour in
+Netgate's upgrade script and has been since 2017: any `pfSense-pkg-*` it cannot
+find in the remote repo is flagged automatic and collected by `pkg autoremove`.
+
+From 1.2.10 the package marks itself vital, which makes `pkg autoremove` skip
+it, so it now survives. **Reinstall the current release afterwards anyway.** A
+major pfSense upgrade can change the FreeBSD base and the PHP version
+underneath the package (2.9.0 moves to FreeBSD 16 and PHP 8.5), and the flag
+only guarantees the files are still there, not that they still run.
+
+If you are coming from a version before 1.2.10, or you restore a config backup
+onto a fresh install, the package will be gone and the symptom is that
+**the firewall loses all DNS.** The `forward-addr: 127.0.0.1@5300` line in the
+DNS Resolver custom options belongs to Unbound, so it survives the upgrade and
+now points at a port with nothing listening. Unbound forwards every query into
+the void, including the firewall's own attempts to reach the package
+repository. To recover: remove the `forward-zone` block from Services > DNS
+Resolver > Custom options, apply, reinstall the package, then put the block
+back.
 
 ## Configuration Guide
 
@@ -129,6 +152,10 @@ forward-zone:
 
 3. Click **Save** and **Apply Changes**
 
+These lines belong to Unbound, not to this package, so they stay behind if the
+package is ever removed and will take the firewall's DNS down with them. See
+[Upgrading pfSense itself](#upgrading-pfsense-itself).
+
 ### Option B: Use as System DNS Directly
 
 To use DNSCrypt Proxy directly via **System > General Setup**:
@@ -142,8 +169,15 @@ Note: The pfSense DNS Server Settings only accepts IP addresses and assumes port
 ## Uninstall
 
 ```bash
-pkg delete pfSense-pkg-dnscrypt-proxy
+pkg delete -f pfSense-pkg-dnscrypt-proxy
 ```
+
+The `-f` is required because the package marks itself vital so that a pfSense
+OS upgrade cannot delete it (see [Upgrading pfSense
+itself](#upgrading-pfsense-itself)). It only bypasses that check, so the
+uninstall is otherwise normal and still runs the package's own cleanup. If you
+prefer, `pkg set -v 0 pfSense-pkg-dnscrypt-proxy` first and then plain `pkg
+delete` does the same thing.
 
 ### Complete Removal (Troubleshooting)
 

--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,7 @@ if pkg info ${PORTNAME} >/dev/null 2>&1; then
     pkg delete -y -f ${PORTNAME}
 fi
 
-pkg add -f ${PKG_FILE}
+pkg add -f -A ${PKG_FILE}
 
 echo "Running post-install..."
 /usr/local/bin/php -f /etc/rc.packages ${PORTNAME} POST-INSTALL || true

--- a/build.sh
+++ b/build.sh
@@ -128,6 +128,10 @@ generate_manifest() {
     # Note: We use a wildcard ABI to support both pfSense CE (FreeBSD 15) and
     # pfSense Plus (FreeBSD 16). This works because dnscrypt-proxy is a
     # statically-linked Go binary with no libc dependencies.
+    #
+    # vital: true survives a pfSense OS upgrade, which autoremoves any
+    # pfSense-pkg-* missing from the Netgate repo. The port must not set it:
+    # a repo package is never flagged, and vital blocks the GUI Remove button.
     cat > "${BUILD_DIR}/+MANIFEST" <<EOF
 name: "${PORTNAME}"
 version: "${PORTVERSION}"
@@ -136,6 +140,7 @@ comment: "pfSense package for DNSCrypt Proxy encrypted DNS client"
 maintainer: "ports@FreeBSD.org"
 prefix: "${PREFIX}"
 abi: "FreeBSD:*:*"
+vital: true
 desc: "pfSense package for DNSCrypt Proxy, an encrypted DNS client supporting DNSCrypt v2 and DNS-over-HTTPS protocols."
 www: "https://github.com/DNSCrypt/dnscrypt-proxy"
 licenselogic: "single"
@@ -269,7 +274,8 @@ set -e
 
 if pkg info ${PORTNAME} >/dev/null 2>&1; then
     echo "Removing existing ${PORTNAME}..."
-    pkg delete -y ${PORTNAME}
+    # -f because the package declares itself vital.
+    pkg delete -y -f ${PORTNAME}
 fi
 
 pkg add -f ${PKG_FILE}

--- a/build/+MANIFEST
+++ b/build/+MANIFEST
@@ -1,10 +1,11 @@
 name: "pfSense-pkg-dnscrypt-proxy"
-version: "1.2.9"
+version: "1.2.10"
 origin: "dns/pfSense-pkg-dnscrypt-proxy"
 comment: "pfSense package for DNSCrypt Proxy encrypted DNS client"
 maintainer: "ports@FreeBSD.org"
 prefix: "/usr/local"
 abi: "FreeBSD:*:*"
+vital: true
 desc: "pfSense package for DNSCrypt Proxy, an encrypted DNS client supporting DNSCrypt v2 and DNS-over-HTTPS protocols."
 www: "https://github.com/DNSCrypt/dnscrypt-proxy"
 licenselogic: "single"

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -860,9 +860,70 @@ EOF;
 }
 
 /**
+ * Find services that will lose DNS resolution when this package goes away.
+ *
+ * Both documented setups point another service at our listener, and neither
+ * of those settings belongs to this package, so they survive the uninstall
+ * and leave the firewall forwarding into a dead port. The failure is delayed:
+ * cached answers keep working until their TTL expires.
+ *
+ * Returns an array of warning strings, empty when nothing depends on us.
+ */
+function dnscrypt_proxy_get_uninstall_warnings() {
+	$pkg_config = dnscrypt_proxy_get_config();
+	$port = !empty($pkg_config['listen_port']) ? $pkg_config['listen_port'] : '5300';
+	$warnings = array();
+
+	// Option A: DNS Resolver forwarding to us. Port 53 may be left implicit.
+	// config_path_enabled(), not !empty(): pfSense writes <enable></enable>,
+	// so the flag is an empty string whose presence is what means enabled.
+	$unbound = config_get_path('unbound', array());
+	if (config_path_enabled('unbound') && !empty($unbound['custom_options'])) {
+		$suffix = ($port == '53') ? '(?:@53)?' : '@' . preg_quote($port, '/');
+		$re = '/^\s*forward-addr:\s*(?:127\.0\.0\.1|::1)' . $suffix . '\s*$/mi';
+		if (preg_match($re, base64_decode($unbound['custom_options']))) {
+			$warnings[] =
+			    "WARNING: the DNS Resolver (Unbound) is forwarding to 127.0.0.1@{$port}, " .
+			    "which this package provided.\n" .
+			    "         That setting belongs to Unbound and is not removed with this " .
+			    "package, so name\n" .
+			    "         resolution will fail as cached answers expire.\n" .
+			    "         Fix: delete the forward-zone block from Services > DNS Resolver > " .
+			    "Custom options,\n" .
+			    "         then Save and Apply Changes.";
+		}
+	}
+
+	// Option B: system DNS pointed at us, which requires us on port 53.
+	if ($port == '53') {
+		foreach (config_get_path('system/dnsserver', array()) as $dnsserver) {
+			if (in_array($dnsserver, array('127.0.0.1', '::1'))) {
+				$warnings[] =
+				    "WARNING: System > General Setup lists {$dnsserver} as a DNS server and " .
+				    "this package was\n" .
+				    "         answering on port 53, so name resolution will fail as cached " .
+				    "answers expire.\n" .
+				    "         Fix: set a working DNS server in System > General Setup, or " .
+				    "re-enable the\n" .
+				    "         DNS Resolver.";
+				break;
+			}
+		}
+	}
+
+	return $warnings;
+}
+
+/**
  * Uninstall the package
  */
 function dnscrypt_proxy_deinstall() {
+	// Warn before the listener goes away, while the config is still readable.
+	foreach (dnscrypt_proxy_get_uninstall_warnings() as $warning) {
+		update_status("\n" . $warning . "\n");
+		log_error("[dnscrypt-proxy] " . str_replace("\n", " ", $warning));
+	}
+
 	// Stop the service
 	if (is_process_running("dnscrypt-proxy")) {
 		mwexec("/usr/bin/killall -q dnscrypt-proxy");

--- a/files/usr/local/pkg/dnscrypt-proxy.inc
+++ b/files/usr/local/pkg/dnscrypt-proxy.inc
@@ -841,11 +841,23 @@ function dnscrypt_proxy_install_binary() {
 function dnscrypt_proxy_write_rcfile() {
 	$rc = array();
 	$rc['file'] = 'dnscrypt-proxy.sh';
+	// The config.xml check covers a Factory Defaults reset. The reset wipes
+	// config.xml but leaves this package installed, and pfSense's
+	// rc.start_packages globs every rc file and starts the ones no registered
+	// package claimed, so without this the daemon comes back at boot with no
+	// GUI able to see or manage it. Deliberately fails open: it only declines
+	// when config.xml is readable and definitely lacks our settings, because a
+	// guard that misfires would leave the firewall with no DNS.
 	$rc['start'] = <<<'EOF'
+CONF=/conf/config.xml
 if [ -f /usr/local/etc/dnscrypt-proxy/dnscrypt-proxy.toml ] && [ -x /usr/local/bin/dnscrypt-proxy ]; then
-	/usr/bin/killall -q dnscrypt-proxy
-	/usr/sbin/daemon -p /var/run/dnscrypt_proxy.pid -f /usr/local/bin/dnscrypt-proxy -config /usr/local/etc/dnscrypt-proxy/dnscrypt-proxy.toml
-	/usr/bin/logger -p daemon.info -t dnscrypt-proxy "Service started"
+	if [ -r "$CONF" ] && ! /usr/bin/grep -q '<dnscryptproxy>' "$CONF"; then
+		/usr/bin/logger -p daemon.notice -t dnscrypt-proxy "Not starting: no configuration in config.xml (package left installed after a factory reset?)"
+	else
+		/usr/bin/killall -q dnscrypt-proxy
+		/usr/sbin/daemon -p /var/run/dnscrypt_proxy.pid -f /usr/local/bin/dnscrypt-proxy -config /usr/local/etc/dnscrypt-proxy/dnscrypt-proxy.toml
+		/usr/bin/logger -p daemon.info -t dnscrypt-proxy "Service started"
+	fi
 fi
 EOF;
 	$rc['stop'] = <<<'EOF'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -34,6 +34,19 @@ set -e
 
 PORTNAME="pfSense-pkg-dnscrypt-proxy"
 
+# Random label, so a warm Unbound cache cannot report success for a resolver
+# that is already broken.
+dns_probe() {
+    _p="$(od -An -N4 -tx1 /dev/urandom | tr -dc '0-9a-f').example.com"
+    timeout 6 drill "${_p}" @127.0.0.1 2>/dev/null \
+        | sed -n 's/.*rcode: \([A-Z]*\).*/\1/p' | head -1
+}
+
+# Baseline before anything is touched. Without it the final check cannot tell
+# "this uninstall broke DNS" from "nothing was ever listening on 127.0.0.1:53",
+# which is the normal state when neither Resolver nor Forwarder is enabled.
+DNS_BEFORE=$(dns_probe || true)
+
 echo "=== Step 1: Stop dnscrypt-proxy if running ==="
 if pgrep -q dnscrypt-proxy 2>/dev/null; then
     echo "Stopping dnscrypt-proxy..."
@@ -236,23 +249,25 @@ echo "Your saved options will be restored on next install."
 
 echo ""
 echo "=== Step 9: Verify DNS still resolves ==="
-# Random label, so a warm Unbound cache cannot mask an already-broken resolver.
-PROBE="$(od -An -N4 -tx1 /dev/urandom | tr -dc '0-9a-f').example.com"
-RCODE=$(timeout 6 drill "${PROBE}" @127.0.0.1 2>/dev/null \
-    | sed -n 's/.*rcode: \([A-Z]*\).*/\1/p' | head -1 || true)
-case "${RCODE}" in
-    NOERROR|NXDOMAIN)
-        echo "Resolver answered ${RCODE} for an uncached name. DNS still works."
+DNS_AFTER=$(dns_probe || true)
+case "${DNS_BEFORE}:${DNS_AFTER}" in
+    *:NOERROR|*:NXDOMAIN)
+        echo "Resolver answered ${DNS_AFTER} for an uncached name. DNS still works."
         ;;
-    *)
-        echo "WARNING: this firewall can no longer resolve DNS."
-        echo "         Got '${RCODE:-no response}' for an uncached name via 127.0.0.1."
+    NOERROR:*|NXDOMAIN:*)
+        echo "WARNING: this firewall resolved DNS before this uninstall and does not now."
+        echo "         127.0.0.1 went from '${DNS_BEFORE}' to '${DNS_AFTER:-no response}'."
         echo ""
         echo "         Something is still pointed at the DNSCrypt Proxy listener,"
         echo "         which no longer exists. Check both:"
         echo "           Services > DNS Resolver > Custom options   (forward-zone to 127.0.0.1@5300)"
         echo "           System > General Setup > DNS Servers       (a loopback address)"
         echo "         Remove it, then Save and Apply Changes."
+        ;;
+    *)
+        echo "Note: 127.0.0.1 did not resolve before this uninstall either"
+        echo "      ('${DNS_BEFORE:-no response}' -> '${DNS_AFTER:-no response}'), so this"
+        echo "      uninstall is not the cause. Nothing to do here."
         ;;
 esac
 REMOTE

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -50,8 +50,13 @@ echo ""
 echo "=== Step 2: Remove pkg registration (if installed via pkg) ==="
 if pkg info "${PORTNAME}" >/dev/null 2>&1; then
     echo "Removing package registration..."
-    pkg delete -y "${PORTNAME}" 2>/dev/null || true
-    echo "Removed."
+    # -f because the package declares itself vital; deinstall scripts still run.
+    if pkg delete -y -f "${PORTNAME}"; then
+        echo "Removed."
+    else
+        echo "WARNING: pkg delete failed. The package is still registered."
+        echo "         Files removed below will leave pkg's database stale."
+    fi
 else
     echo "Not registered as a pkg."
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -233,6 +233,28 @@ echo ""
 echo "=== Config status ==="
 echo "pfSense config.xml settings have been PRESERVED."
 echo "Your saved options will be restored on next install."
+
+echo ""
+echo "=== Step 9: Verify DNS still resolves ==="
+# Random label, so a warm Unbound cache cannot mask an already-broken resolver.
+PROBE="$(od -An -N4 -tx1 /dev/urandom | tr -dc '0-9a-f').example.com"
+RCODE=$(timeout 6 drill "${PROBE}" @127.0.0.1 2>/dev/null \
+    | sed -n 's/.*rcode: \([A-Z]*\).*/\1/p' | head -1 || true)
+case "${RCODE}" in
+    NOERROR|NXDOMAIN)
+        echo "Resolver answered ${RCODE} for an uncached name. DNS still works."
+        ;;
+    *)
+        echo "WARNING: this firewall can no longer resolve DNS."
+        echo "         Got '${RCODE:-no response}' for an uncached name via 127.0.0.1."
+        echo ""
+        echo "         Something is still pointed at the DNSCrypt Proxy listener,"
+        echo "         which no longer exists. Check both:"
+        echo "           Services > DNS Resolver > Custom options   (forward-zone to 127.0.0.1@5300)"
+        echo "           System > General Setup > DNS Servers       (a loopback address)"
+        echo "         Remove it, then Save and Apply Changes."
+        ;;
+esac
 REMOTE
 
 echo ""


### PR DESCRIPTION
Refs #41. A user upgraded to pfSense 2.9.0 and lost all DNS. The package was gone, and the cause is not 2.9.0.

## What happens

`pfSense-upgrade` flags every installed `pfSense-pkg-*` that the Netgate repo does not carry and lets `pkg autoremove` collect it:

```sh
# Remove packages removed from remote repo
for _package in $(_pkg query %n $(_pkg info -E -g ${pkg_prefix}\*)); do
        _pkg rquery -U -r ${product} %v ${_package} >/dev/null && continue
        _exec "_pkg set -A 1 ${_package}" "Scheduling package ${_package} for removal"
done
_exec "_pkg autoremove" ...
```

This package is only ever installed from a file, so it is never in that repo and every OS upgrade removed it. That loop has been there since 2017 (commit `f1e5e549`, "Automatically remove additional packages not available on remote repository", Ticket #7946), so this was never 2.9.0 specific. 2.9.0 is simply the first release since the package got real use.

Removal also runs the deinstall hook, so the daemon stops and the TOML goes. The damage is worse than losing the package: the `forward-addr: 127.0.0.1@5300` line in the DNS Resolver custom options belongs to Unbound, survives untouched, and now points at a dead port. The firewall loses all DNS, including its own ability to reach the package repository to repair itself. Because cached answers keep working until their TTL expires, it degrades over minutes rather than failing outright, which makes it hard to connect back to the upgrade that caused it.

## What changed

| change | why |
|---|---|
| `vital: true` in the generated manifest | `pkg autoremove` selects on `automatic=1 AND vital=0 AND locked=0`, so this alone stops the removal. Only `build.sh` sets it; the port must not, since a package the repo carries is never flagged and vital would then block the GUI Remove button. |
| Install with `-A` | pfSense's two bulk loops, Factory Defaults reset and "Reinstall all packages", iterate `%a == 0` and abort the whole script on the first package they cannot resolve. `-A` takes this package out of both. |
| `-f` on every delete | vital blocks a plain `pkg delete`. Three places needed it: the README, `uninstall.sh`, and `build.sh deploy`, which would otherwise have broken the next deploy rather than this one. |
| Deinstall warns about dependents | Reads config.xml only, no network, so it cannot hang a pkg transaction. Names the exact setting to undo. |
| `uninstall.sh` probes DNS | Random label, so a warm cache cannot report success for a broken resolver, plus a before/after comparison so it never blames itself for a box that never resolved. |
| rc script declines without config | A factory reset leaves the package installed, and `rc.start_packages` starts every rc file that no registered package claimed, so the daemon came back unmanageable. |

## Tradeoffs worth reviewing

**Factory Defaults reset no longer removes this package.** That is the direct consequence of `-A`: the loop skips it instead of dying on it. Files stay on disk, nothing runs, and the README documents `pkg delete -f` for a clean box.

**"Reinstall all packages" already aborted on this package before this branch**, for the same underlying reason, which is worth knowing when weighing the above:

```
$ pfSense-upgrade -y -i pfSense-pkg-dnscrypt-proxy -f
REAL EXIT=1
```

`-A` fixes that pre-existing bug too. On the test box this package sorts 8th of 14, so an abort stranded 6 unrelated packages.

**`vital` and `-A` must stay paired.** With `-A` set, clearing vital by hand leaves the package automatic and unprotected for the next autoremove. The uninstall docs now say `pkg delete -f` and no longer offer clearing the flag as an alternative.

## Verification

No test suite, so this was exercised against a live pfSense 2.8.1 box.

- Installed package reports `auto=1 vital=1`, and the upgrade sequence (`pkg set -A 1` then `pkg autoremove`) reports `Nothing to do`
- Absent from the `%a == 0` list that both bulk loops walk
- `pkg delete -f` run for real: completes, runs the deinstall hook, and the `<dnscryptproxy>` settings block is byte-identical across an uninstall and reinstall round trip
- `pkg delete` without `-f` refuses and changes nothing
- `pkg-static add -f -A` upgrades over a running daemon with the binary intact
- `uninstall.sh` run end to end; step 9 caught the real breakage (`NOERROR` to `no response`)
- rc guard: declines when settings are absent and logs why, starts when the config path is missing (fails open), starts normally otherwise, and does not misfire on the install path where sync runs before registration
- `php -l`, `shellcheck --severity=error` and `ports-check` all clean

Version bumped to 1.2.10 so this is releasable as merged.
