### PR TITLE
ci: verify the arm64 distfile checksum too

### DIFF
--- a/.github/workflows/ports-check.yml
+++ b/.github/workflows/ports-check.yml
@@ -64,3 +64,11 @@ jobs:
 
             cd "${PORTDIR}"
             make check-plist
+
+            # check-plist fetches and checksums only the host arch's distfile,
+            # because DISTFILES is arch-conditional and this VM is amd64. The
+            # arm64 half of distinfo therefore goes unverified, even though
+            # ONLY_FOR_ARCHS lists aarch64. Nothing else checks it: a bad arm64
+            # entry from upstream-update.yml would first surface as a failed
+            # build on a Netgate ARM appliance. Fetch and check it here.
+            make checksum DNSCRYPT_ARCH=arm64


### PR DESCRIPTION
`ports-check` fetches and checksums only the host arch's distfile, because `DISTFILES` is conditional on `ARCH` and the VM is amd64. The arm64 `SHA256` and `SIZE` lines in `distinfo` were therefore never verified by anything, even though `ONLY_FOR_ARCHS` lists `aarch64`.

That was harmless while `distinfo` was hand-written and rarely touched. It is not harmless now that it is generated: `upstream-update.yml` regenerates both entries on every upstream bump, and that step landed 2026-08-14, after the last automated bump in July, so it has never actually run. A bad arm64 entry would first surface as a failed port build on a Netgate ARM appliance.

One line, and it reuses the fetch the framework already does:

```sh
make checksum DNSCRYPT_ARCH=arm64
```

## Verification

Both directions, on this branch.

Passes with the correct `distinfo`, and both arches are now covered:

```
Checksum OK for dnscrypt-proxy-freebsd_amd64-2.1.18.tar.gz.
Checksum OK for dnscrypt-proxy-freebsd_arm64-2.1.18.tar.gz.
```

Fails when the arm64 hash is wrong, checked by flipping one character in a temporary commit that has since been dropped:

```
=> SHA256 Checksum OK for dnscrypt-proxy-freebsd_amd64-2.1.18.tar.gz.
=> SHA256 Checksum mismatch for dnscrypt-proxy-freebsd_arm64-2.1.18.tar.gz.
===>  Refetch for 1 more times files: ...
*** Error code 1
```

Adds about 4 seconds and one 4 MB fetch to a 70 second job.
